### PR TITLE
Add routes to server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ node_modules
 /packages/server/output_manifests
 .DS_Store
 
-# Ignore all files in the public folder
+# Ignore all files in these folders
 /public/*
+/output_manifests/*
 
-# Do not ignore the public folder itself
+# Do not ignore the folders itself
 !/public/
+!/output_manifests/

--- a/packages/generator/generateManifest.js
+++ b/packages/generator/generateManifest.js
@@ -71,7 +71,7 @@ function shouldSkipFile(fileName, ignoreFiles) {
 }
 
 // Load variables from environment
-const projectName = process.env.PROJECT_NAME || "Project_Name";
+const projectName = (process.env.PROJECT_NAME || "project_name").toLowerCase();
 const version = process.env.VERSION || "1.0.0";
 const pathToProject =
   process.env.PATH_TO_PROJECT ||


### PR DESCRIPTION
### What I did:
- Added `/project_list` route inside of `packages/server/server.js` to outputs a project list in a dict with each project name as a key. Their values contain metadata for the launcher such as generatedAt, version, and path to logo/image.
- Added `toLowerCase()` to prevent edge case with project name manifests.
- Updated the `manifest.json` route to take a param for the project name and version. The route then returns the corresponding manifest to the launcher.
- Updated `.gitignore` to keep `output_manifest` folder and ignore content inside folder

### Why I did it:
- I prepared these routes so the launcher will be able to handle multiple games with multiple manifests.
- The next steps are to add UI to the launcher to handle multiple projects and allow the user to download/update their desired version.